### PR TITLE
optional auto-retry after headers['Retry-After'] seconds

### DIFF
--- a/lib/simplespotify/constants.rb
+++ b/lib/simplespotify/constants.rb
@@ -11,4 +11,8 @@ module SimpleSpotify
   # Upper bound when trying to refresh the authentication token
   MAX_RETRIES = 2
 
+  # Should we block the whole program until we can retry a rate-limited request? set to
+  # "please" if you'd like to enable this potentially web-request blocking option
+  RETRY_IF_RATELIMITED = false
+
 end

--- a/lib/simplespotify/errors.rb
+++ b/lib/simplespotify/errors.rb
@@ -5,6 +5,7 @@ module SimpleSpotify
       case status_code
         when 401 then Unauthorized
         when 404 then NotFound
+        when 429 then RateLimited
         when (500..599) then API
         else
           DefaultError
@@ -50,6 +51,9 @@ module SimpleSpotify
     end
 
     class Unauthorized < DefaultError
+    end
+
+    class RateLimited < DefaultError
     end
 
   end


### PR DESCRIPTION
`SimpleSpotify::RETRY_IF_RATELIMITED = 'please'` makes SimpleSpotify sleep `headers['Retry-After']` seconds, which is what spotify would like us to wait for before we will retry the request at max `SimpleSpotify::MAX_RETRIES` times (2, by default).